### PR TITLE
Fix OpenSlES driver sleeping for long time

### DIFF
--- a/app/src/main/cpp/fluidsynth/src/drivers/fluid_opensles.c
+++ b/app/src/main/cpp/fluidsynth/src/drivers/fluid_opensles.c
@@ -326,7 +326,7 @@ void fluid_opensles_adjust_latency(fluid_opensles_audio_driver_t* dev)
     current_time = ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
     long time_delta = dev->next_expected_enqueue_time == 0 ? 0 : dev->next_expected_enqueue_time - current_time;
     if (time_delta == 0)
-        dev->next_expected_enqueue_time += current_time + wait_in_theory;
+        dev->next_expected_enqueue_time = current_time + wait_in_theory;
     else
         dev->next_expected_enqueue_time += wait_in_theory;
     /* take some sleep only if it's running ahead */


### PR DESCRIPTION
The adjust latency method would add current_time and
wait_in_theory time to next_expected_enqueue_time when
it really should continue with filling the buffer without
delay (time_delta == 0).
This caused the Driver to sleep for a lot more time than
needed.