### PR TITLE
Use Callback-Mode of OpenSLES-Driver

### DIFF
--- a/app/src/main/cpp/fluidsynth/src/drivers/fluid_opensles.c
+++ b/app/src/main/cpp/fluidsynth/src/drivers/fluid_opensles.c
@@ -348,8 +348,6 @@ void fluid_opensles_callback(SLAndroidSimpleBufferQueueItf caller, void *pContex
 
     buffer_size = dev->buffer_size;
 
-    fluid_opensles_adjust_latency(dev);
-
     if (dev->callback)
     {
         if (dev->is_sample_format_float) {

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -10,7 +10,12 @@ JNIEXPORT void JNICALL Java_opensles_android_fluidsynth_fluidsynth_1android_1ope
         JNIEnv *env,
         jobject /* this */,
         jstring sf2path) {
+    // Init settings
     settings = new_fluid_settings();
+    fluid_settings_setstr(settings, "audio.driver", "opensles");
+    fluid_settings_setint(settings, "audio.opensles.use-callback-mode", 1);
+    fluid_settings_setint(settings, "audio.period-size", 64);
+
     synth = new_fluid_synth(settings);
 
     // Init soundfont
@@ -18,7 +23,6 @@ JNIEXPORT void JNICALL Java_opensles_android_fluidsynth_fluidsynth_1android_1ope
     fluid_synth_sfload(synth, nativeSf2Path, true);
     env->ReleaseStringUTFChars(sf2path, nativeSf2Path);
 
-    fluid_settings_setstr(settings, "audio.driver", "opensles");
     adriver = new_fluid_audio_driver(settings, synth);
 }
 


### PR DESCRIPTION
Use Callback-Mode because the other mode is flawed. There is no way to ensure a buffer finished playing. In Callback mode every time a Buffer finished playing the callback is triggered to enqueue new data. Therefore the call to adjust_latency is also useless, new data is already needed, no need to wait.